### PR TITLE
Inherited widget

### DIFF
--- a/lib/auth_provider.dart
+++ b/lib/auth_provider.dart
@@ -1,0 +1,15 @@
+
+import 'package:flutter/material.dart';
+import 'package:login_demo/auth.dart';
+
+class AuthProvider extends InheritedWidget {
+  AuthProvider({Key key, Widget child, this.auth}) : super(key: key, child: child);
+  final BaseAuth auth;
+
+  @override
+  bool updateShouldNotify(InheritedWidget oldWidget) => true;
+
+  static AuthProvider of(BuildContext context) {
+    return (context.inheritFromWidgetOfExactType(AuthProvider) as AuthProvider);
+  }
+}

--- a/lib/home_page.dart
+++ b/lib/home_page.dart
@@ -1,13 +1,13 @@
 import 'package:flutter/material.dart';
-import 'package:login_demo/auth.dart';
+import 'package:login_demo/auth_provider.dart';
 
 class HomePage extends StatelessWidget {
-  HomePage({this.auth, this.onSignedOut});
-  final BaseAuth auth;
+  HomePage({this.onSignedOut});
   final VoidCallback onSignedOut;
 
-  void _signOut() async {
+  void _signOut(BuildContext context) async {
     try {
+      var auth = AuthProvider.of(context).auth;
       await auth.signOut();
       onSignedOut();
     } catch (e) {
@@ -24,7 +24,7 @@ class HomePage extends StatelessWidget {
             FlatButton(
                 child: Text('Logout',
                     style: TextStyle(fontSize: 17.0, color: Colors.white)),
-                onPressed: _signOut)
+                onPressed: () => _signOut(context))
           ],
         ),
         body: Container(

--- a/lib/login_page.dart
+++ b/lib/login_page.dart
@@ -1,9 +1,8 @@
 import 'package:flutter/material.dart';
-import 'package:login_demo/auth.dart';
+import 'package:login_demo/auth_provider.dart';
 
 class LoginPage extends StatefulWidget {
-  LoginPage({this.auth, this.onSignedIn});
-  final BaseAuth auth;
+  LoginPage({this.onSignedIn});
   final VoidCallback onSignedIn;
 
   @override
@@ -34,12 +33,13 @@ class _LoginPageState extends State<LoginPage> {
   void validateAndSubmit() async {
     if (validateAndSave()) {
       try {
+        var auth = AuthProvider.of(context).auth;
         if (_formType == FormType.login) {
           String userId =
-              await widget.auth.signInWithEmailAndPassword(_email, _password);
+              await auth.signInWithEmailAndPassword(_email, _password);
           print('Signed in: $userId');
         } else {
-          String userId = await widget.auth
+          String userId = await auth
               .createUserWithEmailAndPassword(_email, _password);
           print('Registered user: $userId');
         }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:login_demo/auth.dart';
+import 'package:login_demo/auth_provider.dart';
 import 'package:login_demo/root_page.dart';
 
 void main() {
@@ -10,10 +11,14 @@ class MyApp extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
-        title: 'Flutter login demo',
-        theme: ThemeData(
-          primarySwatch: Colors.blue,
-        ),
-        home: RootPage(auth: Auth()));
+      title: 'Flutter login demo',
+      theme: ThemeData(
+        primarySwatch: Colors.blue,
+      ),
+      home: AuthProvider(
+        auth: Auth(),
+        child: RootPage(),
+      ),
+    );
   }
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -10,14 +10,14 @@ void main() {
 class MyApp extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
-    return MaterialApp(
-      title: 'Flutter login demo',
-      theme: ThemeData(
-        primarySwatch: Colors.blue,
-      ),
-      home: AuthProvider(
-        auth: Auth(),
-        child: RootPage(),
+    return AuthProvider(
+      auth: Auth(),
+      child: MaterialApp(
+        title: 'Flutter login demo',
+        theme: ThemeData(
+          primarySwatch: Colors.blue,
+        ),
+        home: RootPage(),
       ),
     );
   }

--- a/lib/root_page.dart
+++ b/lib/root_page.dart
@@ -2,10 +2,9 @@ import 'package:flutter/material.dart';
 import 'package:login_demo/auth.dart';
 import 'package:login_demo/home_page.dart';
 import 'package:login_demo/login_page.dart';
+import 'package:login_demo/auth_provider.dart';
 
 class RootPage extends StatefulWidget {
-  RootPage({this.auth});
-  final BaseAuth auth;
 
   @override
   State<StatefulWidget> createState() => _RootPageState();
@@ -19,9 +18,11 @@ enum AuthStatus {
 class _RootPageState extends State<RootPage> {
   AuthStatus authStatus = AuthStatus.notSignedIn;
 
-  initState() {
-    super.initState();
-    widget.auth.currentUser().then((userId) {
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    var auth = AuthProvider.of(context).auth;
+    auth.currentUser().then((userId) {
       setState(() {
         authStatus =
             userId == null ? AuthStatus.notSignedIn : AuthStatus.signedIn;
@@ -46,12 +47,10 @@ class _RootPageState extends State<RootPage> {
     switch (authStatus) {
       case AuthStatus.notSignedIn:
         return LoginPage(
-          auth: widget.auth,
           onSignedIn: _signedIn,
         );
       case AuthStatus.signedIn:
         return HomePage(
-          auth: widget.auth,
           onSignedOut: _signedOut,
         );
     }


### PR DESCRIPTION
- [x] Add `AuthProvider` as an implementation of `InheritedWidget`
- [x] Use it to get access to `auth` in `RootPage`, `LoginPage`, `HomePage`
- [x] Remove `auth` injection in `RootPage`, `LoginPage`, `HomePage`